### PR TITLE
textured_max_lod でテクスチャの無い建物のジオメトリが消える不具合の修正

### DIFF
--- a/nusamai/src/transformer/transform/lods.rs
+++ b/nusamai/src/transformer/transform/lods.rs
@@ -34,36 +34,34 @@ impl Transform for FilterLodTransform {
         // Extract the largest LOD with a texture. If there is no texture, extract the largest LOD.
         match self.mode {
             LodFilterMode::TexturedHighest => {
+                // Pick the highest LOD that actually has a texture; fall back to the highest LOD.
+                //
+                // FIX: the previous implementation called the DESTRUCTIVE `edit_tree` inside the
+                // probing loop and judged "has texture" from the whole-entity `appearance_store`
+                // (LOD-independent, and never pruned by `edit_tree`). For entities without any
+                // texture this progressively destroyed the geometry tree, making whole (untextured)
+                // buildings disappear. We now probe NON-destructively using `polygon_textures`
+                // (per-polygon texture assignment, already resolved by ApplyAppearanceTransform,
+                // which runs before this transform) and call `edit_tree` exactly once.
                 let available_lods = find_lods(&entity.root) & self.mask;
-                let mut highest_textured_lod = None;
-
-                // The “maximum LOD” is set from the beginning. If the texture does not exist, the maximum LOD is returned immediately.
-                let highest_available_lod = available_lods.highest_lod().unwrap_or(0);
-
-                // Creating a reverse-order iterator with ev
-                for lod in (0..=highest_available_lod).rev() {
-                    if available_lods.0 & (1 << lod) != 0 {
-                        edit_tree(&mut entity.root, lod);
-
-                        let has_textures = {
-                            let appearance = entity.appearance_store.read().unwrap();
-                            !appearance.textures.is_empty()
-                        };
-
-                        // If a LOD with the texture is found, save it and exit.
-                        if has_textures {
-                            highest_textured_lod = Some(lod);
+                let Some(highest_available_lod) = available_lods.highest_lod() else {
+                    return;
+                };
+                let target_lod = {
+                    let geom = entity.geometry_store.read().unwrap();
+                    let mut chosen = None;
+                    for lod in (0..=highest_available_lod).rev() {
+                        if available_lods.has_lod(lod)
+                            && lod_has_texture(&entity.root, lod, &geom.polygon_textures)
+                        {
+                            chosen = Some(lod);
                             break;
                         }
                     }
-                }
-
-                // If “highest_textured_lod” is not None, use “highest_textured_lod”
-                // If it is None, use ”highest_available_lod”
-                if let Some(lod) = highest_textured_lod.or(Some(highest_available_lod)) {
-                    edit_tree(&mut entity.root, lod);
-                    out.push(entity);
-                }
+                    chosen.unwrap_or(highest_available_lod)
+                };
+                edit_tree(&mut entity.root, target_lod);
+                out.push(entity);
             }
             LodFilterMode::Highest => {
                 let lods = find_lods(&entity.root) & self.mask;
@@ -117,6 +115,40 @@ fn edit_tree(value: &mut Value, target_lod: u8) -> bool {
             !arr.is_empty()
         }
         _ => true,
+    }
+}
+
+/// Whether any geometry at `target_lod` has a textured polygon (non-destructive).
+///
+/// `GeometryRef { pos, len }` spans `[pos, pos+len)` of the polygons, aligned with
+/// `polygon_textures` (per-polygon texture assignment). `polygon_textures` is empty when
+/// appearance resolution is disabled, in which case this returns false (callers fall back
+/// to the highest LOD).
+fn lod_has_texture(value: &Value, target_lod: u8, polygon_textures: &[Option<u32>]) -> bool {
+    match value {
+        Value::Object(obj) => {
+            if let ObjectStereotype::Feature { geometries, .. } = &obj.stereotype {
+                for geom in geometries {
+                    if geom.lod == target_lod {
+                        let start = geom.pos as usize;
+                        let end = start + geom.len as usize;
+                        if polygon_textures
+                            .get(start..end)
+                            .is_some_and(|s| s.iter().any(|t| t.is_some()))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            obj.attributes
+                .values()
+                .any(|v| lod_has_texture(v, target_lod, polygon_textures))
+        }
+        Value::Array(arr) => arr
+            .iter()
+            .any(|v| lod_has_texture(v, target_lod, polygon_textures)),
+        _ => false,
     }
 }
 
@@ -204,7 +236,81 @@ impl BitAnd for LodMask {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::RwLock;
+
+    use nusamai_citygml::{
+        geometry::{GeometryRef, GeometryType},
+        object::Object,
+        GeometryStore,
+    };
+    use nusamai_plateau::Entity;
+
     use super::*;
+    use crate::pipeline::feedback::watcher;
+
+    /// Build a single-feature entity from `(lod, polygon_index)` geometries and per-polygon
+    /// texture assignments, run `TexturedHighest`, and return the surviving geometry LODs.
+    fn run_textured_highest(geoms: &[(u8, u32)], polygon_textures: Vec<Option<u32>>) -> Vec<u8> {
+        let geometries: Vec<GeometryRef> = geoms
+            .iter()
+            .map(|&(lod, pos)| GeometryRef {
+                ty: GeometryType::Solid,
+                lod,
+                pos,
+                len: 1,
+            })
+            .collect();
+        let geometry_store = GeometryStore {
+            polygon_textures,
+            ..Default::default()
+        };
+        let entity = Entity {
+            root: Value::Object(Object {
+                typename: "bldg:Building".into(),
+                attributes: Default::default(),
+                stereotype: ObjectStereotype::Feature {
+                    id: "b1".into(),
+                    geometries,
+                },
+            }),
+            base_url: url::Url::parse("file:///dummy").unwrap(),
+            geometry_store: RwLock::new(geometry_store).into(),
+            appearance_store: Default::default(),
+        };
+        let (_watcher, feedback, _canceller) = watcher();
+        let mut transform = FilterLodTransform::new(LodMask::all(), LodFilterMode::TexturedHighest);
+        let mut out = Vec::new();
+        transform.transform(&feedback, entity, &mut out);
+        let mut lods = Vec::new();
+        for entity in &out {
+            if let Value::Object(obj) = &entity.root {
+                if let ObjectStereotype::Feature { geometries, .. } = &obj.stereotype {
+                    lods.extend(geometries.iter().map(|g| g.lod));
+                }
+            }
+        }
+        lods.sort_unstable();
+        lods
+    }
+
+    #[test]
+    fn textured_highest_keeps_geometry_when_untextured() {
+        // A building with no textured polygon must NOT vanish: it falls back to the highest LOD.
+        // (Regression: the previous destructive probe loop left such entities with empty geometry.)
+        let lods = run_textured_highest(&[(1, 0), (2, 1)], vec![None, None]);
+        assert_eq!(lods, vec![2]);
+    }
+
+    #[test]
+    fn textured_highest_prefers_a_textured_lod() {
+        // Highest LOD (2) is untextured but a lower LOD (1) is textured -> pick the textured one.
+        let lods = run_textured_highest(&[(1, 0), (2, 1)], vec![Some(0), None]);
+        assert_eq!(lods, vec![1]);
+        // Highest LOD (2) is textured -> pick it.
+        let lods = run_textured_highest(&[(1, 0), (2, 1)], vec![None, Some(0)]);
+        assert_eq!(lods, vec![2]);
+    }
+
     #[test]
     fn test_lod_mask() {
         let mut mask = LodMask::default();


### PR DESCRIPTION
## 概要

`--sink gltf -t use_lod=textured_max_lod` で変換すると、テクスチャを持たない建物（住宅地に多いです）のジオメトリが出力から丸ごと消えてしまいます。テクスチャ付きの建物は問題なく出ます。

さいたま市（大宮周辺）のデータを変換していて、住宅街がごっそり抜け落ちることで気づきました。あるメッシュ（`53396479`）だと、修正前は約 1,900 頂点しか残らないのに、修正後は約 62,000 頂点になります。衝突判定用に別途 GeoJSON で出しているフットプリント側には建物があるのに、glTF 側だけ消えている、という状態でした。

## 原因

`nusamai/src/transformer/transform/lods.rs` の `LodFilterMode::TexturedHighest` です。

```rust
for lod in (0..=highest_available_lod).rev() {
    if available_lods.0 & (1 << lod) != 0 {
        edit_tree(&mut entity.root, lod);                   // ①
        let has_textures = !appearance.textures.is_empty(); // ②
        if has_textures { highest_textured_lod = Some(lod); break; }
    }
}
```

- ① `edit_tree` は `geometries.retain(|g| g.lod == target_lod)` で対象以外の LOD のジオメトリを破棄します。これを探索ループの中で毎回呼んでいるので、LOD を降りながら順にジオメトリを壊してしまい、あとから戻せません。
- ② テクスチャの有無を `appearance_store`（エンティティ全体が持つテクスチャ画像の有無）で見ていますが、これは `edit_tree` では刈られないため、LOD ごとの判定になっていません（実質「このエンティティにテクスチャが 1 枚でもあるか」という、LOD によらない定数になっています）。

この結果、テクスチャ付きのエンティティは最初の反復（最上位 LOD）で `break` するのでたまたま正しく動きますが、テクスチャの無いエンティティはループが最後まで回ってジオメトリが空になり、消えてしまいます（本来は「最上位 LOD にフォールバック」したいはずの分岐です）。

## 修正

`polygon_textures`（ポリゴン単位のテクスチャ割り当て。`ApplyAppearanceTransform` が `FilterLodTransform` より前に解決します）を使って、各 LOD にテクスチャ付きのポリゴンがあるかを **非破壊で** 判定するようにしました。テクスチャを持つ最上位 LOD を選び、無ければ最上位 LOD にフォールバックして、`edit_tree` は対象 LOD を決めてから一度だけ呼びます。これでテクスチャの無い建物もジオメトリを保ったまま出力されます。

`textured_max_lod` は `set_appearance(true)` で appearance を有効化するため、本変換の時点で `polygon_textures` は解決済みです。万一空（appearance 未解決）の場合は最上位 LOD にフォールバックするので、ジオメトリが失われることはありません。

## テスト

`lods.rs` にユニットテストを追加しました。

- テクスチャの無いフィーチャがジオメトリを失わない（最上位 LOD にフォールバックする）
- 最上位 LOD が無テクスチャでも、テクスチャを持つ下位 LOD があればそちらを選ぶ／最上位 LOD がテクスチャ付きならそれを選ぶ

```
cargo test -p nusamai --lib transformer::transform::lods
```

## 動作確認

実データで再変換して確認しました。

- さいたま市（大宮・住宅メッシュ）: 抜け落ちていた住宅が復活しました。
- 東京（千代田・商業メッシュ `53394611`）: 頂点数は変化なし（元からテクスチャ付きなので影響を受けません）。
